### PR TITLE
Avoid adding the working directory to PATH

### DIFF
--- a/src/hardcaml_verilator.ml
+++ b/src/hardcaml_verilator.ml
@@ -172,16 +172,6 @@ let with_tmp_stdout ~verbose ~f =
   Option.iter tmp_stdout ~f:Unix.unlink
 ;;
 
-let path_with_required_system_tools () =
-  let path = Sys.getenv "PATH" |> Option.value ~default:"" in
-  let tools =
-    [ "python3"; "ccache" ]
-    |> List.map ~f:(fun tool -> Filename.dirname tool)
-    |> String.concat ~sep:":"
-  in
-  [%string "%{path}:%{tools}"]
-;;
-
 let run_command_exn ?(verbose = false) command =
   with_tmp_stdout ~verbose ~f:(fun tmp_stdout ->
     if verbose then print_endline command;
@@ -190,8 +180,6 @@ let run_command_exn ?(verbose = false) command =
       | Some tmp_stdout -> [%string "%{command} &>%{tmp_stdout}"]
       | None -> command
     in
-    let path = path_with_required_system_tools () in
-    let command = [%string "PATH=\"%{path}\" %{command}"] in
     match Unix.system command with
     | Ok () -> ()
     | Error e ->


### PR DESCRIPTION
## Summary

- remove the PATH wrapper around external commands
- preserve the caller environment inherited by `Unix.system`
- avoid appending the working directory to executable lookup

`path_with_required_system_tools` called `Filename.dirname` on the literal names `python3` and `ccache`. Both resolve to `.`, so every command ran with `.:.` appended to `PATH`; it did not add any tool directories. Letting `Unix.system` inherit the existing environment keeps lookup behavior predictable and avoids making the working directory executable-searchable.

## Validation

- `git diff --check`
- verified no `PATH=` wrapper or `path_with_required_system_tools` references remain under `src/` and `test/`